### PR TITLE
feat(api): add endpoints for buoys

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,41 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+args_bin = []
+bin = "tmp/api"
+cmd = "go build -o tmp/api ./cmd/api"
+delay = 0
+exclude_dir = ["web/node_modules", "web/dist/assets"]
+exclude_file = []
+exclude_regex = ["_test.go"]
+exclude_unchanged = false
+follow_symlink = false
+full_bin = ""
+include_dir = []
+include_ext = ["go", "tpl", "tmpl", "html"]
+include_file = []
+kill_delay = "0s"
+log = "build-errors.log"
+rerun = false
+rerun_delay = 600
+send_interrupt = false
+stop_on_error = false
+
+[color]
+app = ""
+build = "yellow"
+main = "magenta"
+runner = "green"
+watcher = "cyan"
+
+[log]
+main_only = false
+time = false
+
+[misc]
+clean_on_exit = false
+
+[screen]
+clear_on_rebuild = false
+keep_scroll = true

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,13 +1,22 @@
 ---
 actions:
-  - .github/**/*
+  - changed-files:
+      - any-glob-to-any-file: ['.github/*']
 config:
-  - .editorconfig
-  - .gitignore
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.air.toml'
+          - '.dockerignore'
+          - '.editorconfig'
+          - '.gitignore'
+          - '.github/*'
+          - 'renovate.json'
 dependencies:
-  - renovate.json
+  - changed-files:
+      - any-glob-to-any-file: ['package.json', 'package-lock.json']
 docs:
-  - '**/*.md'
-  - docs/**/*
+  - changed-files:
+      - any-glob-to-any-file: ['docs/*', '**/*.md']
 test:
-  - tests/**/*
+  - changed-files:
+      - any-glob-to-any-file: ['tests/*']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6  # v2.8.1
         with:
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             api.github.com:443
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,9 @@ node_modules
 coverage
 *.test
 
-# production
+# builds
 dist
+tmp
 
 # workspaces
 go.work

--- a/.taskfiles/api.taskfile.yml
+++ b/.taskfiles/api.taskfile.yml
@@ -2,6 +2,11 @@
 version: '3'
 
 tasks:
+  build:
+    desc: "Compile"
+    cmds:
+      - go build ./cmd/api
+
   run:
     desc: "Compile and run."
     cmds:

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log/slog"
 	"os"
 	"runtime/debug"
 	"sync"
@@ -9,6 +8,7 @@ import (
 	"github.com/clairBuoyant/swellhub/internal/app"
 	"github.com/clairBuoyant/swellhub/internal/http"
 	"github.com/clairBuoyant/swellhub/pkg/env"
+	"github.com/clairBuoyant/swellhub/pkg/log"
 )
 
 func main() {
@@ -16,7 +16,7 @@ func main() {
 		Port: env.GetInt("PORT", 4000),
 	}
 
-	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	log := log.InitLoggerJSON()
 
 	var wg sync.WaitGroup
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -102,9 +102,13 @@ func (app *Application) ErrorMessage(w http.ResponseWriter, r *http.Request, sta
 	}
 }
 
-func (app *Application) ServerError(w http.ResponseWriter, r *http.Request, err error) {
+func (app *Application) ServerError(w http.ResponseWriter, r *http.Request, err error, code int) {
+	message := err.Error()
+	if code == 0 {
+		code = http.StatusInternalServerError
+		message = "server encountered a problem and could not process your request"
+	}
 	app.ReportServerError(r, err)
 
-	message := "The server encountered a problem and could not process your request"
-	app.ErrorMessage(w, r, http.StatusInternalServerError, message, nil)
+	app.ErrorMessage(w, r, code, message, nil)
 }

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -1,23 +1,64 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/clairBuoyant/swellhub/internal/errors"
 	"github.com/clairBuoyant/swellhub/internal/response"
+	"github.com/clairBuoyant/swellhub/pkg/noaa"
 )
 
-type Application interface {
-	ServerError(w http.ResponseWriter, r *http.Request, err error)
+type application interface {
+	ServerError(w http.ResponseWriter, r *http.Request, err error, code int)
 }
 
-func Status(app Application) http.HandlerFunc {
+func Buoy(app application) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		dataset := noaa.RealtimeDataset(r.URL.Query().Get("dataset"))
+		if dataset == "" {
+			dataset = noaa.TXT
+		}
+
+		if valid := dataset.IsValid(); !valid {
+			app.ServerError(w, r, errors.NewAppError(http.StatusBadRequest, fmt.Sprintf("unknown dataset %s", dataset), nil), http.StatusBadRequest)
+			return
+		}
+
+		// TODO: add validation for stationID too
+		data, err := noaa.Realtime(r.PathValue("stationID"), dataset)
+		if err != nil {
+			// TODO: dynamically provide http status code
+			app.ServerError(w, r, errors.NewAppError(http.StatusNotAcceptable, "failed to encode response", err), http.StatusNotAcceptable)
+			return
+		}
+		if err := response.JSON(w, http.StatusOK, data); err != nil {
+			app.ServerError(w, r, errors.NewAppError(http.StatusInternalServerError, "failed to encode response", err), 0)
+		}
+	}
+}
+
+func Buoys(app application) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data, err := noaa.ActiveStations()
+		if err != nil {
+			app.ServerError(w, r, errors.NewAppError(http.StatusBadRequest, "failed to retrieve active stations from NDBC", err), http.StatusBadRequest)
+			return
+		}
+
+		if err := response.JSON(w, http.StatusOK, data); err != nil {
+			app.ServerError(w, r, errors.NewAppError(http.StatusInternalServerError, "failed to encode response", err), 0)
+		}
+	}
+}
+
+func Status(app application) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data := map[string]string{
 			"status": "OK",
 		}
 		if err := response.JSON(w, http.StatusOK, data); err != nil {
-			app.ServerError(w, r, errors.NewAppError(http.StatusInternalServerError, "failed to encode response", err))
+			app.ServerError(w, r, errors.NewAppError(http.StatusInternalServerError, "failed to encode response", err), 0)
 		}
 	}
 }

--- a/internal/http/routes.go
+++ b/internal/http/routes.go
@@ -9,6 +9,9 @@ import (
 func NewRouter(app *app.Application) *http.ServeMux {
 	mux := http.NewServeMux()
 
+	mux.HandleFunc("/buoy/{stationID}", Buoy(app))
+	mux.HandleFunc("/buoys", Buoys(app))
+
 	mux.HandleFunc("/status", Status(app))
 
 	return mux

--- a/pkg/env/doc.go
+++ b/pkg/env/doc.go
@@ -1,0 +1,2 @@
+// Package env provides the functionality to retrieve environment variables.
+package env

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -7,15 +7,25 @@ import (
 	"strings"
 )
 
-func GetString(key, defaultValue string) string {
+// GetBool returns a boolean representation of the given key.
+//
+// The key is false whenever its value if 0, no, false, none or an
+// empty string. Any other value will be interpreted as true.
+func GetBool(key string, defaultValue bool) bool {
 	value, exists := os.LookupEnv(key)
 	if !exists {
 		return defaultValue
 	}
 
-	return value
+	boolValue, err := strconv.ParseBool(value)
+	if err != nil {
+		panic(err)
+	}
+
+	return boolValue
 }
 
+// GetInt returns the value of the provided key, converted to int.
 func GetInt(key string, defaultValue int) int {
 	value, exists := os.LookupEnv(key)
 	if !exists {
@@ -30,18 +40,14 @@ func GetInt(key string, defaultValue int) int {
 	return intValue
 }
 
-func GetBool(key string, defaultValue bool) bool {
+// GetString returns the string value of the provided key.
+func GetString(key, defaultValue string) string {
 	value, exists := os.LookupEnv(key)
 	if !exists {
 		return defaultValue
 	}
 
-	boolValue, err := strconv.ParseBool(value)
-	if err != nil {
-		panic(err)
-	}
-
-	return boolValue
+	return value
 }
 
 // ReadFromFile reads a config/env file and returns a map of key-value pairs.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,50 @@
+package log
+
+import (
+	"log/slog"
+	"os"
+)
+
+const (
+	LevelTrace = slog.Level(-8)
+	LevelDebug = slog.LevelDebug
+	LevelInfo  = slog.LevelInfo
+	LevelWarn  = slog.LevelWarn
+	LevelError = slog.LevelError
+	LevelFatal = slog.Level(12)
+)
+
+var LevelNames = map[slog.Leveler]string{
+	LevelTrace: "TRACE",
+	LevelFatal: "FATAL",
+}
+
+// Enums for Level
+const (
+	TraceLevel slog.Level = LevelTrace
+	DebugLevel slog.Level = LevelDebug
+	InfoLevel  slog.Level = LevelInfo
+	WarnLevel  slog.Level = LevelWarn
+	ErrorLevel slog.Level = LevelError
+	FatalLevel slog.Level = LevelFatal
+)
+
+// InitLoggerJSON initializes global logger with full json format.
+func InitLoggerJSON() *slog.Logger {
+	opts := &slog.HandlerOptions{
+		Level: LevelTrace,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.LevelKey {
+				level := a.Value.Any().(slog.Level)
+				levelLabel, exists := LevelNames[level]
+				if !exists {
+					levelLabel = level.String()
+				}
+				a.Value = slog.StringValue(levelLabel)
+			}
+			return a
+		},
+	}
+	h := slog.NewJSONHandler(os.Stdout, opts)
+	return slog.New(h)
+}

--- a/pkg/noaa/constants.go
+++ b/pkg/noaa/constants.go
@@ -5,8 +5,8 @@ const (
 	// NDBC Base URL
 	baseUrlNDBC = "https://www.ndbc.noaa.gov"
 
-	ActiveStations = baseUrlNDBC + "/activestations"
-	Realtime       = baseUrlNDBC + "/data/realtime2"
+	ActiveStationsURL = baseUrlNDBC + "/activestations"
+	RealtimeURL       = baseUrlNDBC + "/data/realtime2"
 )
 
 // NOAA Endpoints

--- a/pkg/noaa/errors.go
+++ b/pkg/noaa/errors.go
@@ -1,0 +1,69 @@
+package noaa
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// NOAAError represents a standard error message.
+type NOAAError struct {
+	Message string
+	Err     error
+}
+
+func (e *NOAAError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("error: %v - %v", e.Message, e.Err)
+	}
+	return fmt.Sprintf("error: %v", e.Message)
+}
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+func (e *NOAAError) Unwrap() error {
+	return e.Err
+}
+
+// NewError creates a new NOAAError.
+func NewError(message string, err error) *NOAAError {
+	return &NOAAError{
+		Message: message,
+		Err:     err,
+	}
+}
+
+// NOAARequestError represents an application error with a HTTP status code.
+type NOAARequestError struct {
+	Code    int
+	Message string
+	Err     error
+}
+
+func (e *NOAARequestError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("http error(%d): %v - %v", e.Code, e.Message, e.Err)
+	}
+	return fmt.Sprintf("http error(%d): %v", e.Code, e.Message)
+}
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+func (e *NOAARequestError) Unwrap() error {
+	return e.Err
+}
+
+// NewRequestError creates a new NOAARequestError.
+func NewRequestError(code int, message string, err error) *NOAARequestError {
+	return &NOAARequestError{
+		Code:    code,
+		Message: message,
+		Err:     err,
+	}
+}
+
+var (
+	ReqErrNotFound       = NewRequestError(http.StatusNotFound, "resource not found", nil)
+	ReqErrInternalServer = NewRequestError(http.StatusInternalServerError, "internal server error", nil)
+)

--- a/web/src/routes/public.tsx
+++ b/web/src/routes/public.tsx
@@ -1,7 +1,6 @@
 import { lazy } from 'react';
 
-// eslint-disable-next-line import/no-unresolved
-const AuthRoutes = lazy(() => import('@features/auth/routes')); // TODO: resolve eslint error
+const AuthRoutes = lazy(() => import('@features/auth/routes'));
 
 export const publicRoutes = [
   {


### PR DESCRIPTION
## Summary

- [x] Add `GET /buoy/{stationID}`
- [x] Add `GET /buoys`
- [x] Scaffold `pkg/log` for standardized logging experience with `slog`
- [x] Use `pkg/log` for `cmd/api`
- [x] Add configuration file for [`air`](https://github.com/air-verse/air) to support hot reloading in development environments
- [x] Refactor handling of errors for both API and `pkg/noaa` to set foundation for further refinement in future

## Documentation

New endpoints directly relies on `pkg/noaa` to retrieve data. This will be replaced with DB calls.