### PR TITLE
chore(ci): add Go build/vet/test workflow with a Postgres service

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,53 @@
+name: go-ci
+
+on:
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/go-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: swellhub
+          POSTGRES_PASSWORD: swellhub
+          POSTGRES_DB: swellhub
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U swellhub -d swellhub"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      # Integration tests (e.g. internal/store) self-migrate against this and
+      # run; packages that don't use it are unaffected. Suites skip it when unset.
+      TEST_DATABASE_URL: postgres://swellhub:swellhub@127.0.0.1:5432/swellhub?sslmode=disable
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Stub embedded web assets
+        # cmd/api embeds web/dist (built separately by the web pipeline); a stub
+        # satisfies the //go:embed for this Go-only job.
+        run: mkdir -p web/dist && printf '<!doctype html>\n' > web/dist/index.html
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./... -count=1


### PR DESCRIPTION
## What

Adds **`.github/workflows/go-ci.yml`** — the first CI that actually builds and tests the Go code. Runs on PRs touching `**.go` / `go.mod` / `go.sum` (and its own file, so it self-validates here):

- `go build ./...`, `go vet ./...`, `go test ./... -count=1`
- A **`postgres:17-alpine` service container** + `TEST_DATABASE_URL`, so the `internal/store` integration tests **self-migrate and run in CI** instead of skipping (they call `db.Migrate` themselves). Packages that don't use the DB are unaffected.

Closes #221 · part of #206 (E9).

## Why now
CI currently only lints + scans (semgrep/CodeQL) — no Go build/test job, so our tests run only locally and don't gate PRs. Landing this **before M0-3** means the ingestion cron and the DB-backed reads get gated by the store tests.

## Notes
- Independent of #219 (based on `main`). On this PR it runs `main`'s tests (M0-1 handler tests) green; once #219's `internal/store` is on `main`, the same workflow runs those integration tests on every Go PR.
- Follows the lightweight style of the existing `proto-linter` workflow (tags, no harden-runner). SHA-pinning all actions could be a later consistency pass.
