### PR TITLE
feat(ingest): observation ingest command + hourly cron (M0-3)

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -1,0 +1,29 @@
+name: ingest
+
+on:
+  schedule:
+    - cron: '0 * * * *' # hourly, on the hour (UTC)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ingest
+  cancel-in-progress: false
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Apply migrations
+        run: go run ./cmd/migrate up
+      - name: Ingest observations
+        run: go run ./cmd/ingest

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   ingest:
     runs-on: ubuntu-latest
-    environment: ingest
+    environment: preprod
     timeout-minutes: 15
     env:
       DB_URL: ${{ secrets.DB_URL }}

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ingest
@@ -15,14 +16,22 @@ concurrency:
 jobs:
   ingest:
     runs-on: ubuntu-latest
+    environment: ingest
+    timeout-minutes: 15
     env:
       DB_URL: ${{ secrets.DB_URL }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
+      - name: Connect to the ingest tailnet
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ secrets.TS_AUDIENCE }}
+          tags: tag:swellhub-ingest
       - name: Apply migrations
         run: go run ./cmd/migrate up
       - name: Ingest observations

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -16,7 +16,7 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DB_URL: ${{ secrets.DB_URL }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.taskfiles/db.taskfile.yml
+++ b/.taskfiles/db.taskfile.yml
@@ -28,22 +28,22 @@ tasks:
   migrate:
     desc: Apply migrations and seed spots
     cmds:
-      - DATABASE_URL="${DATABASE_URL:-{{.DSN}}}" go run ./cmd/migrate up
+      - DB_URL="${DB_URL:-{{.DSN}}}" go run ./cmd/migrate up
 
   ingest:
     desc: Run the observation ingest once against the local DB
     cmds:
-      - DATABASE_URL="${DATABASE_URL:-{{.DSN}}}" go run ./cmd/ingest
+      - DB_URL="${DB_URL:-{{.DSN}}}" go run ./cmd/ingest
 
   rollback:
     desc: Roll back the most recent migration
     cmds:
-      - DATABASE_URL="${DATABASE_URL:-{{.DSN}}}" go run ./cmd/migrate down
+      - DB_URL="${DB_URL:-{{.DSN}}}" go run ./cmd/migrate down
 
   status:
     desc: Show migration status
     cmds:
-      - DATABASE_URL="${DATABASE_URL:-{{.DSN}}}" go run ./cmd/migrate status
+      - DB_URL="${DB_URL:-{{.DSN}}}" go run ./cmd/migrate status
 
   test:
     desc: Run store integration tests against the local DB

--- a/.taskfiles/db.taskfile.yml
+++ b/.taskfiles/db.taskfile.yml
@@ -30,6 +30,11 @@ tasks:
     cmds:
       - DATABASE_URL="${DATABASE_URL:-{{.DSN}}}" go run ./cmd/migrate up
 
+  ingest:
+    desc: Run the observation ingest once against the local DB
+    cmds:
+      - DATABASE_URL="${DATABASE_URL:-{{.DSN}}}" go run ./cmd/ingest
+
   rollback:
     desc: Roll back the most recent migration
     cmds:

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -35,7 +35,12 @@ func main() {
 	defer pool.Close()
 
 	stations := mappedStations()
-	n := ingest.Run(ctx, store.New(pool), noaa.Realtime, stations, logger)
+	n, err := ingest.Run(ctx, store.New(pool), noaa.Realtime, stations, logger)
+	if err != nil {
+		logger.Error("ingest completed with failures", "stations", len(stations), "observations_inserted", n, "error", err)
+		pool.Close()
+		os.Exit(1)
+	}
 	logger.Info("ingest complete", "stations", len(stations), "observations_inserted", n)
 }
 

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -1,0 +1,56 @@
+// Command ingest fetches realtime NDBC observations for the buoys mapped to the
+// configured spots and upserts them into Postgres. Intended to run on a
+// schedule (see .github/workflows/ingest.yml).
+//
+// Usage: DATABASE_URL=postgres://... go run ./cmd/ingest
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/clairBuoyant/swellhub/internal/db"
+	"github.com/clairBuoyant/swellhub/internal/ingest"
+	"github.com/clairBuoyant/swellhub/internal/spot"
+	"github.com/clairBuoyant/swellhub/internal/store"
+	"github.com/clairBuoyant/swellhub/pkg/log"
+	"github.com/clairBuoyant/swellhub/pkg/noaa"
+)
+
+func main() {
+	logger := log.InitLoggerJSON()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		logger.Error("DATABASE_URL is required")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	pool, err := db.NewPool(ctx, dsn)
+	if err != nil {
+		logger.Error("connect postgres", "error", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	stations := mappedStations()
+	n := ingest.Run(ctx, store.New(pool), noaa.Realtime, stations, logger)
+	logger.Info("ingest complete", "stations", len(stations), "observations_inserted", n)
+}
+
+// mappedStations returns the de-duplicated NDBC station IDs across all spots,
+// preserving first-seen order.
+func mappedStations() []string {
+	seen := make(map[string]bool)
+	var ids []string
+	for _, s := range spot.All() {
+		for _, id := range s.BuoyIDs {
+			if !seen[id] {
+				seen[id] = true
+				ids = append(ids, id)
+			}
+		}
+	}
+	return ids
+}

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -2,7 +2,7 @@
 // configured spots and upserts them into Postgres. Intended to run on a
 // schedule (see .github/workflows/ingest.yml).
 //
-// Usage: DATABASE_URL=postgres://... go run ./cmd/ingest
+// Usage: DB_URL=postgres://... go run ./cmd/ingest
 package main
 
 import (
@@ -20,9 +20,9 @@ import (
 func main() {
 	logger := log.InitLoggerJSON()
 
-	dsn := os.Getenv("DATABASE_URL")
+	dsn := os.Getenv("DB_URL")
 	if dsn == "" {
-		logger.Error("DATABASE_URL is required")
+		logger.Error("DB_URL is required")
 		os.Exit(1)
 	}
 

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,7 +1,7 @@
 // Command migrate runs database migrations and, on "up", seeds the spot config
 // from the in-repo source of truth (internal/spot). Idempotent; safe to re-run.
 //
-// Usage: DATABASE_URL=postgres://... go run ./cmd/migrate [up|down|status|reset]
+// Usage: DB_URL=postgres://... go run ./cmd/migrate [up|down|status|reset]
 package main
 
 import (
@@ -20,9 +20,9 @@ func main() {
 		command = os.Args[1]
 	}
 
-	dsn := os.Getenv("DATABASE_URL")
+	dsn := os.Getenv("DB_URL")
 	if dsn == "" {
-		log.Fatal("DATABASE_URL is required")
+		log.Fatal("DB_URL is required")
 	}
 
 	if err := db.RunGoose(dsn, command); err != nil {

--- a/cmd/noaa/main.go
+++ b/cmd/noaa/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/clairBuoyant/swellhub/pkg/noaa"
 )
@@ -33,7 +34,7 @@ func main() {
 			os.Exit(1)
 		}
 		for _, mo := range mos {
-			fmt.Printf("Observation Date: %s, Average Wave Period: %f, Wave Height: %f\n", mo.Datetime, mo.AverageWavePeriod, mo.WaveHeight)
+			fmt.Printf("Observation Date: %s, Average Wave Period: %s, Wave Height: %s\n", mo.Datetime, reading(mo.AverageWavePeriod), reading(mo.WaveHeight))
 		}
 
 	case "active":
@@ -52,6 +53,13 @@ func main() {
 		fmt.Println("Error: invalid mode. Use 'realtime' or 'active'")
 		printUsageAndExit()
 	}
+}
+
+func reading(v *float32) string {
+	if v == nil {
+		return "MM"
+	}
+	return strconv.FormatFloat(float64(*v), 'f', -1, 32)
 }
 
 func printUsageAndExit() {

--- a/internal/db/query/observations.sql
+++ b/internal/db/query/observations.sql
@@ -1,4 +1,4 @@
--- name: UpsertObservation :exec
+-- name: UpsertObservation :execrows
 INSERT INTO observations (
     station_id, observed_at, wave_height_m, dominant_wave_period_s, average_wave_period_s,
     wave_direction_deg, wind_direction_deg, wind_speed_mps, wind_gust_mps,

--- a/internal/db/sqlc/observations.sql.go
+++ b/internal/db/sqlc/observations.sql.go
@@ -39,7 +39,7 @@ func (q *Queries) LatestObservation(ctx context.Context, stationID string) (Obse
 	return i, err
 }
 
-const upsertObservation = `-- name: UpsertObservation :exec
+const upsertObservation = `-- name: UpsertObservation :execrows
 INSERT INTO observations (
     station_id, observed_at, wave_height_m, dominant_wave_period_s, average_wave_period_s,
     wave_direction_deg, wind_direction_deg, wind_speed_mps, wind_gust_mps,
@@ -65,8 +65,8 @@ type UpsertObservationParams struct {
 	SeaLevelPressureHpa pgtype.Float8
 }
 
-func (q *Queries) UpsertObservation(ctx context.Context, arg UpsertObservationParams) error {
-	_, err := q.db.Exec(ctx, upsertObservation,
+func (q *Queries) UpsertObservation(ctx context.Context, arg UpsertObservationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, upsertObservation,
 		arg.StationID,
 		arg.ObservedAt,
 		arg.WaveHeightM,
@@ -80,5 +80,8 @@ func (q *Queries) UpsertObservation(ctx context.Context, arg UpsertObservationPa
 		arg.WaterTemperatureC,
 		arg.SeaLevelPressureHpa,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/internal/db/sqlc/querier.go
+++ b/internal/db/sqlc/querier.go
@@ -13,7 +13,7 @@ type Querier interface {
 	InsertFeedback(ctx context.Context, arg InsertFeedbackParams) (Feedback, error)
 	LatestObservation(ctx context.Context, stationID string) (Observation, error)
 	ListSpots(ctx context.Context) ([]Spot, error)
-	UpsertObservation(ctx context.Context, arg UpsertObservationParams) error
+	UpsertObservation(ctx context.Context, arg UpsertObservationParams) (int64, error)
 	UpsertSpot(ctx context.Context, arg UpsertSpotParams) error
 }
 

--- a/internal/http/spot.go
+++ b/internal/http/spot.go
@@ -94,9 +94,6 @@ func toProtoSpot(sp spot.Spot) *spotv1.Spot {
 }
 
 func toProtoConditions(buoyID string, o noaa.MeteorologicalObservation) *spotv1.Conditions {
-	// TODO(@kylejb): noaa.parseValue maps the NDBC "MM" sentinel to 0, so we
-	// can't yet distinguish missing from a real zero. Until that layer is made
-	// missing-aware, every field is reported as present.
 	return &spotv1.Conditions{
 		BuoyId:              buoyID,
 		ObservedAt:          timestamppb.New(o.Datetime),
@@ -113,5 +110,18 @@ func toProtoConditions(buoyID string, o noaa.MeteorologicalObservation) *spotv1.
 	}
 }
 
-func f64p(v float32) *float64 { f := float64(v); return &f }
-func i32p(v int16) *int32     { i := int32(v); return &i }
+func f64p(v *float32) *float64 {
+	if v == nil {
+		return nil
+	}
+	f := float64(*v)
+	return &f
+}
+
+func i32p(v *int16) *int32 {
+	if v == nil {
+		return nil
+	}
+	i := int32(*v)
+	return &i
+}

--- a/internal/http/spot_test.go
+++ b/internal/http/spot_test.go
@@ -62,8 +62,8 @@ func TestGetSpotNotFound(t *testing.T) {
 func TestGetSpotConditions(t *testing.T) {
 	obs := noaa.MeteorologicalObservation{
 		Datetime:   time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC),
-		WaveHeight: 1.5,
-		WindSpeed:  4.0,
+		WaveHeight: float32Ptr(1.5),
+		WindSpeed:  float32Ptr(4.0),
 	}
 
 	// rockaway-90th maps buoys ["44065", "44025"].
@@ -130,6 +130,11 @@ func TestGetSpotConditions(t *testing.T) {
 			if conds.GetWaveHeightM() != 1.5 {
 				t.Errorf("wave height = %v, want 1.5", conds.GetWaveHeightM())
 			}
+			if conds.WindGustMps != nil {
+				t.Errorf("missing wind gust = %v, want absent", conds.GetWindGustMps())
+			}
 		})
 	}
 }
+
+func float32Ptr(v float32) *float32 { return &v }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1,0 +1,43 @@
+// Package ingest fetches realtime NDBC observations for a set of stations and
+// upserts them, starting the durable observation history (the "data clock").
+package ingest
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/clairBuoyant/swellhub/pkg/noaa"
+)
+
+// Upserter persists a single observation, returning rows inserted (0 if it
+// already existed). *store.PgStore satisfies it.
+type Upserter interface {
+	UpsertObservation(ctx context.Context, stationID string, o noaa.MeteorologicalObservation) (int64, error)
+}
+
+// RealtimeFunc fetches realtime observations for a station (noaa.Realtime).
+type RealtimeFunc func(stationID string, dataset noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error)
+
+// Run fetches realtime observations for each station and upserts every returned
+// row (idempotent on station+datetime). It is best-effort: an error for one
+// station is logged and does not abort the others. Returns the number of
+// observations newly inserted (dupes count as 0).
+func Run(ctx context.Context, store Upserter, fetch RealtimeFunc, stationIDs []string, logger *slog.Logger) int {
+	var inserted int
+	for _, id := range stationIDs {
+		obs, err := fetch(id, noaa.TXT)
+		if err != nil {
+			logger.Warn("buoy fetch failed", "buoy", id, "error", err)
+			continue
+		}
+		for _, o := range obs {
+			n, err := store.UpsertObservation(ctx, id, o)
+			if err != nil {
+				logger.Warn("upsert failed", "buoy", id, "observed_at", o.Datetime, "error", err)
+				continue
+			}
+			inserted += int(n)
+		}
+	}
+	return inserted
+}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -4,6 +4,8 @@ package ingest
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/clairBuoyant/swellhub/pkg/noaa"
@@ -21,23 +23,27 @@ type RealtimeFunc func(stationID string, dataset noaa.RealtimeDataset) ([]noaa.M
 // Run fetches realtime observations for each station and upserts every returned
 // row (idempotent on station+datetime). It is best-effort: an error for one
 // station is logged and does not abort the others. Returns the number of
-// observations newly inserted (dupes count as 0).
-func Run(ctx context.Context, store Upserter, fetch RealtimeFunc, stationIDs []string, logger *slog.Logger) int {
+// observations newly inserted (dupes count as 0). All stations are attempted;
+// any fetch or persistence failures are joined and returned after processing.
+func Run(ctx context.Context, store Upserter, fetch RealtimeFunc, stationIDs []string, logger *slog.Logger) (int, error) {
 	var inserted int
+	var failures []error
 	for _, id := range stationIDs {
 		obs, err := fetch(id, noaa.TXT)
 		if err != nil {
 			logger.Warn("buoy fetch failed", "buoy", id, "error", err)
+			failures = append(failures, fmt.Errorf("fetch buoy %s: %w", id, err))
 			continue
 		}
 		for _, o := range obs {
 			n, err := store.UpsertObservation(ctx, id, o)
 			if err != nil {
 				logger.Warn("upsert failed", "buoy", id, "observed_at", o.Datetime, "error", err)
+				failures = append(failures, fmt.Errorf("upsert buoy %s at %s: %w", id, o.Datetime, err))
 				continue
 			}
 			inserted += int(n)
 		}
 	}
-	return inserted
+	return inserted, errors.Join(failures...)
 }

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -37,15 +37,16 @@ func TestRun(t *testing.T) {
 			return two, nil
 		case "EMPTY":
 			return nil, nil
-		case "ERR":
-			return nil, errors.New("ndbc down")
 		}
 		return nil, nil
 	}
 
 	st := &fakeStore{}
-	// GOOD -> 2 upserts, EMPTY -> 0, ERR -> fetch error (skipped).
-	n := Run(context.Background(), st, fetch, []string{"GOOD", "EMPTY", "ERR"}, discardLogger())
+	// GOOD -> 2 upserts, EMPTY -> 0.
+	n, err := Run(context.Background(), st, fetch, []string{"GOOD", "EMPTY"}, discardLogger())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
 	if n != 2 {
 		t.Errorf("upserted = %d, want 2", n)
 	}
@@ -61,8 +62,29 @@ func TestRunContinuesPastUpsertError(t *testing.T) {
 	}
 	st := &fakeStore{failOn: "BAD"}
 	// BAD upsert fails (logged, skipped); OK succeeds.
-	n := Run(context.Background(), st, fetch, []string{"BAD", "OK"}, discardLogger())
+	n, err := Run(context.Background(), st, fetch, []string{"BAD", "OK"}, discardLogger())
 	if n != 1 {
 		t.Errorf("upserted = %d, want 1", n)
+	}
+	if err == nil {
+		t.Fatal("Run error = nil, want partial-failure error")
+	}
+}
+
+func TestRunReportsFetchErrorAfterContinuing(t *testing.T) {
+	fetchErr := errors.New("ndbc down")
+	fetch := func(id string, _ noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+		if id == "BAD" {
+			return nil, fetchErr
+		}
+		return []noaa.MeteorologicalObservation{{Datetime: time.Now()}}, nil
+	}
+
+	n, err := Run(context.Background(), &fakeStore{}, fetch, []string{"BAD", "OK"}, discardLogger())
+	if n != 1 {
+		t.Errorf("inserted = %d, want 1", n)
+	}
+	if !errors.Is(err, fetchErr) {
+		t.Fatalf("Run error = %v, want wrapped fetch error", err)
 	}
 }

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1,0 +1,68 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/clairBuoyant/swellhub/pkg/noaa"
+)
+
+type fakeStore struct {
+	upserts int
+	failOn  string
+}
+
+func (f *fakeStore) UpsertObservation(_ context.Context, stationID string, _ noaa.MeteorologicalObservation) (int64, error) {
+	if stationID == f.failOn {
+		return 0, errors.New("db error")
+	}
+	f.upserts++
+	return 1, nil
+}
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestRun(t *testing.T) {
+	two := []noaa.MeteorologicalObservation{
+		{Datetime: time.Now()},
+		{Datetime: time.Now().Add(-time.Hour)},
+	}
+	fetch := func(id string, _ noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+		switch id {
+		case "GOOD":
+			return two, nil
+		case "EMPTY":
+			return nil, nil
+		case "ERR":
+			return nil, errors.New("ndbc down")
+		}
+		return nil, nil
+	}
+
+	st := &fakeStore{}
+	// GOOD -> 2 upserts, EMPTY -> 0, ERR -> fetch error (skipped).
+	n := Run(context.Background(), st, fetch, []string{"GOOD", "EMPTY", "ERR"}, discardLogger())
+	if n != 2 {
+		t.Errorf("upserted = %d, want 2", n)
+	}
+	if st.upserts != 2 {
+		t.Errorf("store.upserts = %d, want 2", st.upserts)
+	}
+}
+
+func TestRunContinuesPastUpsertError(t *testing.T) {
+	obs := []noaa.MeteorologicalObservation{{Datetime: time.Now()}}
+	fetch := func(string, noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+		return obs, nil
+	}
+	st := &fakeStore{failOn: "BAD"}
+	// BAD upsert fails (logged, skipped); OK succeeds.
+	n := Run(context.Background(), st, fetch, []string{"BAD", "OK"}, discardLogger())
+	if n != 1 {
+		t.Errorf("upserted = %d, want 1", n)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -116,9 +116,6 @@ func (s *PgStore) UpsertSpot(ctx context.Context, sp spot.Spot) error {
 // UpsertObservation inserts an observation, returning the number of rows
 // inserted (0 if it already existed).
 func (s *PgStore) UpsertObservation(ctx context.Context, stationID string, o noaa.MeteorologicalObservation) (int64, error) {
-	// TODO(#220): noaa.parseValue maps the NDBC "MM" sentinel to 0, so every
-	// reading is stored as present. Make the noaa layer missing-aware so these
-	// nullable columns reflect true absence.
 	return s.q.UpsertObservation(ctx, sqlc.UpsertObservationParams{
 		StationID:           stationID,
 		ObservedAt:          ts(o.Datetime),
@@ -198,9 +195,19 @@ func spotFromRow(r sqlc.Spot) spot.Spot {
 
 func ts(t time.Time) pgtype.Timestamptz { return pgtype.Timestamptz{Time: t, Valid: true} }
 
-func f8(v float32) pgtype.Float8 { return pgtype.Float8{Float64: float64(v), Valid: true} }
+func f8(v *float32) pgtype.Float8 {
+	if v == nil {
+		return pgtype.Float8{}
+	}
+	return pgtype.Float8{Float64: float64(*v), Valid: true}
+}
 
-func i4(v int16) pgtype.Int4 { return pgtype.Int4{Int32: int32(v), Valid: true} }
+func i4(v *int16) pgtype.Int4 {
+	if v == nil {
+		return pgtype.Int4{}
+	}
+	return pgtype.Int4{Int32: int32(*v), Valid: true}
+}
 
 func f8p(p *float64) pgtype.Float8 {
 	if p == nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -55,7 +55,7 @@ type Store interface {
 	ListSpots(ctx context.Context) ([]spot.Spot, error)
 	GetSpot(ctx context.Context, id string) (spot.Spot, error)
 	UpsertSpot(ctx context.Context, s spot.Spot) error
-	UpsertObservation(ctx context.Context, stationID string, o noaa.MeteorologicalObservation) error
+	UpsertObservation(ctx context.Context, stationID string, o noaa.MeteorologicalObservation) (int64, error)
 	LatestObservation(ctx context.Context, stationID string) (Observation, error)
 	InsertFeedback(ctx context.Context, f Feedback) (int64, error)
 }
@@ -113,7 +113,9 @@ func (s *PgStore) UpsertSpot(ctx context.Context, sp spot.Spot) error {
 	})
 }
 
-func (s *PgStore) UpsertObservation(ctx context.Context, stationID string, o noaa.MeteorologicalObservation) error {
+// UpsertObservation inserts an observation, returning the number of rows
+// inserted (0 if it already existed).
+func (s *PgStore) UpsertObservation(ctx context.Context, stationID string, o noaa.MeteorologicalObservation) (int64, error) {
 	// TODO(#220): noaa.parseValue maps the NDBC "MM" sentinel to 0, so every
 	// reading is stored as present. Make the noaa layer missing-aware so these
 	// nullable columns reflect true absence.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -75,8 +75,8 @@ func TestObservationsLatest(t *testing.T) {
 	st, _ := testStore(t)
 	ctx := context.Background()
 
-	older := noaa.MeteorologicalObservation{Datetime: time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC), WaveHeight: 1.0}
-	newer := noaa.MeteorologicalObservation{Datetime: time.Date(2026, 6, 14, 11, 0, 0, 0, time.UTC), WaveHeight: 1.4}
+	older := noaa.MeteorologicalObservation{Datetime: time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC), WaveHeight: float32Ptr(1.0)}
+	newer := noaa.MeteorologicalObservation{Datetime: time.Date(2026, 6, 14, 11, 0, 0, 0, time.UTC), WaveHeight: float32Ptr(1.4)}
 	for _, o := range []noaa.MeteorologicalObservation{older, newer} {
 		if _, err := st.UpsertObservation(ctx, "TESTBUOY", o); err != nil {
 			t.Fatalf("UpsertObservation: %v", err)
@@ -103,11 +103,16 @@ func TestObservationsLatest(t *testing.T) {
 	if float32(*got.WaveHeightM) != 1.4 {
 		t.Errorf("latest wave height = %v, want 1.4", *got.WaveHeightM)
 	}
+	if got.WindSpeedMps != nil {
+		t.Errorf("latest missing wind speed = %v, want nil", *got.WindSpeedMps)
+	}
 
 	if _, err := st.LatestObservation(ctx, "NOBUOY"); err != store.ErrNotFound {
 		t.Errorf("LatestObservation(NOBUOY) err = %v, want ErrNotFound", err)
 	}
 }
+
+func float32Ptr(v float32) *float32 { return &v }
 
 func TestInsertFeedback(t *testing.T) {
 	st, _ := testStore(t)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -78,13 +78,15 @@ func TestObservationsLatest(t *testing.T) {
 	older := noaa.MeteorologicalObservation{Datetime: time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC), WaveHeight: 1.0}
 	newer := noaa.MeteorologicalObservation{Datetime: time.Date(2026, 6, 14, 11, 0, 0, 0, time.UTC), WaveHeight: 1.4}
 	for _, o := range []noaa.MeteorologicalObservation{older, newer} {
-		if err := st.UpsertObservation(ctx, "TESTBUOY", o); err != nil {
+		if _, err := st.UpsertObservation(ctx, "TESTBUOY", o); err != nil {
 			t.Fatalf("UpsertObservation: %v", err)
 		}
 	}
-	// Re-upsert is idempotent (ON CONFLICT DO NOTHING).
-	if err := st.UpsertObservation(ctx, "TESTBUOY", newer); err != nil {
+	// Re-upsert is idempotent (ON CONFLICT DO NOTHING) -> 0 rows inserted.
+	if n, err := st.UpsertObservation(ctx, "TESTBUOY", newer); err != nil {
 		t.Fatalf("re-UpsertObservation: %v", err)
+	} else if n != 0 {
+		t.Errorf("re-upsert inserted %d rows, want 0", n)
 	}
 
 	got, err := st.LatestObservation(ctx, "TESTBUOY")

--- a/pkg/noaa/noaa.go
+++ b/pkg/noaa/noaa.go
@@ -53,17 +53,26 @@ func request(url string) ([]byte, int, error) {
 	return body, response.StatusCode, nil
 }
 
-func parseValue(value string) (float32, error) {
+func parseValue(value string) (*float32, error) {
 	if value == "MM" {
-		return 0, nil
+		return nil, nil
 	}
 
 	parsedValue, err := strconv.ParseFloat(value, 32)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	return float32(parsedValue), nil
+	v := float32(parsedValue)
+	return &v, nil
+}
+
+func direction(value *float32) *int16 {
+	if value == nil {
+		return nil
+	}
+	v := int16(*value)
+	return &v
 }
 
 func parseRecordToStruct(record []string, mo *MeteorologicalObservation) error {
@@ -82,7 +91,7 @@ func parseRecordToStruct(record []string, mo *MeteorologicalObservation) error {
 	mo.Datetime = time.Date(int(year), time.Month(month), int(day), int(hour), int(minute), 0, 0, time.UTC)
 
 	if value, err := parseValue(rowValues[5]); err == nil {
-		mo.WindDirection = int16(value)
+		mo.WindDirection = direction(value)
 	} else {
 		return err
 	}
@@ -118,7 +127,7 @@ func parseRecordToStruct(record []string, mo *MeteorologicalObservation) error {
 	}
 
 	if value, err := parseValue(rowValues[11]); err == nil {
-		mo.WaveDirection = int16(value)
+		mo.WaveDirection = direction(value)
 	} else {
 		return err
 	}

--- a/pkg/noaa/noaa_test.go
+++ b/pkg/noaa/noaa_test.go
@@ -1,0 +1,39 @@
+package noaa
+
+import "testing"
+
+func TestParseValuePreservesMissingAndZero(t *testing.T) {
+	missing, err := parseValue("MM")
+	if err != nil {
+		t.Fatalf("parseValue(MM): %v", err)
+	}
+	if missing != nil {
+		t.Fatalf("parseValue(MM) = %v, want nil", *missing)
+	}
+
+	zero, err := parseValue("0.0")
+	if err != nil {
+		t.Fatalf("parseValue(0.0): %v", err)
+	}
+	if zero == nil || *zero != 0 {
+		t.Fatalf("parseValue(0.0) = %v, want pointer to zero", zero)
+	}
+}
+
+func TestParseRecordPreservesMissingReadings(t *testing.T) {
+	var observation MeteorologicalObservation
+	record := []string{"2026 06 20 18 00 MM 0.0 MM 1.2 8 6 MM 1018.2 22.1 19.4 MM MM MM MM"}
+
+	if err := parseRecordToStruct(record, &observation); err != nil {
+		t.Fatalf("parseRecordToStruct: %v", err)
+	}
+	if observation.WindDirection != nil || observation.WindGust != nil || observation.WaveDirection != nil {
+		t.Fatal("missing readings were reported as present")
+	}
+	if observation.WindSpeed == nil || *observation.WindSpeed != 0 {
+		t.Fatalf("real zero wind speed = %v, want pointer to zero", observation.WindSpeed)
+	}
+	if observation.WaveHeight == nil || *observation.WaveHeight != 1.2 {
+		t.Fatalf("wave height = %v, want 1.2", observation.WaveHeight)
+	}
+}

--- a/pkg/noaa/realtime.go
+++ b/pkg/noaa/realtime.go
@@ -54,20 +54,20 @@ func (d RealtimeDataset) IsValid() bool {
 
 type MeteorologicalObservation struct {
 	Datetime            time.Time `json:"datetime"`
-	WindDirection       int16     `json:"windDirection"`
-	WindSpeed           float32   `json:"windSpeed"`
-	WindGust            float32   `json:"windGust"`
-	WaveHeight          float32   `json:"waveHeight"`
-	DominantWavePeriod  float32   `json:"dominantWavePeriod"`
-	AverageWavePeriod   float32   `json:"averageWavePeriod"`
-	WaveDirection       int16     `json:"waveDirection"`
-	SeaLevelPressure    float32   `json:"seaLevelPressure"`
-	PressureTendency    float32   `json:"pressureTendency"`
-	AirTemperature      float32   `json:"airTemperature"`
-	WaterTemperature    float32   `json:"waterTemperature"`
-	DewpointTemperature float32   `json:"dewpointTemperature"`
-	Visibility          float32   `json:"visibility"`
-	Tide                float32   `json:"tide"`
+	WindDirection       *int16    `json:"windDirection"`
+	WindSpeed           *float32  `json:"windSpeed"`
+	WindGust            *float32  `json:"windGust"`
+	WaveHeight          *float32  `json:"waveHeight"`
+	DominantWavePeriod  *float32  `json:"dominantWavePeriod"`
+	AverageWavePeriod   *float32  `json:"averageWavePeriod"`
+	WaveDirection       *int16    `json:"waveDirection"`
+	SeaLevelPressure    *float32  `json:"seaLevelPressure"`
+	PressureTendency    *float32  `json:"pressureTendency"`
+	AirTemperature      *float32  `json:"airTemperature"`
+	WaterTemperature    *float32  `json:"waterTemperature"`
+	DewpointTemperature *float32  `json:"dewpointTemperature"`
+	Visibility          *float32  `json:"visibility"`
+	Tide                *float32  `json:"tide"`
 }
 
 type WaveSummaryObservation struct {
@@ -87,21 +87,21 @@ type WaveSummaryObservation struct {
 // Encodes time.Time object to ISODateString
 func (o MeteorologicalObservation) MarshalJSON() ([]byte, error) {
 	metObs := struct {
-		Datetime            string  `json:"datetime"`
-		WindDirection       int16   `json:"windDirection"`
-		WindSpeed           float32 `json:"windSpeed"`
-		WindGust            float32 `json:"windGust"`
-		WaveHeight          float32 `json:"waveHeight"`
-		DominantWavePeriod  float32 `json:"dominantWavePeriod"`
-		AverageWavePeriod   float32 `json:"averageWavePeriod"`
-		WaveDirection       int16   `json:"waveDirection"`
-		SeaLevelPressure    float32 `json:"seaLevelPressure"`
-		PressureTendency    float32 `json:"pressureTendency"`
-		AirTemperature      float32 `json:"airTemperature"`
-		WaterTemperature    float32 `json:"waterTemperature"`
-		DewpointTemperature float32 `json:"dewpointTemperature"`
-		Visibility          float32 `json:"visibility"`
-		Tide                float32 `json:"tide"`
+		Datetime            string   `json:"datetime"`
+		WindDirection       *int16   `json:"windDirection"`
+		WindSpeed           *float32 `json:"windSpeed"`
+		WindGust            *float32 `json:"windGust"`
+		WaveHeight          *float32 `json:"waveHeight"`
+		DominantWavePeriod  *float32 `json:"dominantWavePeriod"`
+		AverageWavePeriod   *float32 `json:"averageWavePeriod"`
+		WaveDirection       *int16   `json:"waveDirection"`
+		SeaLevelPressure    *float32 `json:"seaLevelPressure"`
+		PressureTendency    *float32 `json:"pressureTendency"`
+		AirTemperature      *float32 `json:"airTemperature"`
+		WaterTemperature    *float32 `json:"waterTemperature"`
+		DewpointTemperature *float32 `json:"dewpointTemperature"`
+		Visibility          *float32 `json:"visibility"`
+		Tide                *float32 `json:"tide"`
 	}{
 		Datetime:            o.Datetime.Format((time.RFC3339)),
 		WindDirection:       o.WindDirection,


### PR DESCRIPTION
## What

M0-3a — the **observation ingest**: captures NDBC realtime observations into Postgres on an hourly schedule.

Refs #210 · Closes #220 · part of #207 (E10). DB-backed `SpotService` reads are split into **#223** (M0-3b). Issue #210 stays open until the scheduled workflow is proven against preprod.

## How

- **`internal/ingest.Run`** — for each station, `noaa.Realtime` → upsert every returned row. All stations are attempted, then fetch/write failures are returned together so Actions reports partial ingestion as failed.
- **Missing readings** — NDBC `MM` remains absent through NOAA parsing, protobuf mapping, JSON, and nullable Postgres columns instead of becoming a real zero.
- **`cmd/ingest`** — dedupes the buoys mapped to the seed spots (44065, 44025, 44091); fails if `DB_URL` is unset/unreachable or any station fails.
- **`store.UpsertObservation`** returns rows inserted (`:execrows`), so the ingest reports *new* observations per run, not rows processed.
- **`.github/workflows/ingest.yml`** — hourly schedule plus manual dispatch, with concurrency protection, the existing `preprod` environment, and a SHA-pinned Tailscale action using GitHub OIDC.
- **`task db:ingest`** for local runs.

## Verified

- Real NDBC → local Postgres first run: `observations_inserted: 11467`.
- Re-run: `observations_inserted: 0`, idempotent on `(station, observed_at)`.
- `go test ./...`, store integration tests, `go vet ./...`, and `go build ./...` pass.
- Tests cover missing-vs-zero readings and partial fetch/write failures.

## Deployment gate

The cron is intentionally not ready to merge until #228 provisions the temporary rk1-k3s Postgres service and private Tailscale path. The GitHub `preprod` environment must contain:

- `DB_URL`
- `TS_OAUTH_CLIENT_ID`
- `TS_AUDIENCE`

After deployment, manually dispatch `ingest`, verify migrations and row growth, observe at least two scheduled runs, then close #210.
