### PR TITLE
chore(ci): externalize CI DB creds and gate integration tests by build tag

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -14,26 +14,27 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    environment: test
     services:
       postgres:
         image: postgres:17-alpine
         env:
-          POSTGRES_USER: swellhub
-          POSTGRES_PASSWORD: swellhub
-          POSTGRES_DB: swellhub
+          POSTGRES_USER: ${{ secrets.DB_USERNAME }}
+          POSTGRES_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.DB_NAME }}
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U swellhub -d swellhub"
+          --health-cmd "pg_isready"
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
 
     env:
-      # Integration tests (e.g. internal/store) self-migrate against this and
-      # run; packages that don't use it are unaffected. Suites skip it when unset.
-      TEST_DATABASE_URL: postgres://swellhub:swellhub@127.0.0.1:5432/swellhub?sslmode=disable
+      # Integration tests (//go:build integration, e.g. internal/store) connect to
+      # TEST_DB_URL and self-migrate; they run with the integration tag below.
+      # Secret names match the infrastructure-neutral contract in env.tmpl.
+      TEST_DB_URL: postgres://${{ secrets.DB_USERNAME }}:${{ secrets.DB_PASSWORD }}@127.0.0.1:5432/${{ secrets.DB_NAME }}?sslmode=disable
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -50,4 +51,4 @@ jobs:
       - name: Vet
         run: go vet ./...
       - name: Test
-        run: go test ./... -count=1
+        run: go test -tags=integration ./... -count=1

--- a/.taskfiles/db.taskfile.yml
+++ b/.taskfiles/db.taskfile.yml
@@ -2,7 +2,7 @@
 version: '3'
 
 vars:
-  DSN: 'postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@127.0.0.1:5432/$POSTGRES_DB?sslmode=disable'
+  DSN: 'postgres://$DB_USERNAME:$DB_PASSWORD@127.0.0.1:5432/$DB_NAME?sslmode=disable'
 
 tasks:
   env:
@@ -48,4 +48,4 @@ tasks:
   test:
     desc: Run store integration tests against the local DB
     cmds:
-      - TEST_DATABASE_URL="${TEST_DATABASE_URL:-{{.DSN}}}" go test ./internal/store/... -count=1
+      - TEST_DB_URL="${TEST_DB_URL:-{{.DSN}}}" go test -tags=integration ./internal/store/... -count=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
     image: postgres:17-alpine
     container_name: swellhub-postgres
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env (see env.tmpl)}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env (see env.tmpl)}
-      POSTGRES_DB: ${POSTGRES_DB:-swellhub}
+      POSTGRES_USER: ${DB_USERNAME:?set DB_USERNAME in .env (see env.tmpl)}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env (see env.tmpl)}
+      POSTGRES_DB: ${DB_NAME:-swellhub}
     ports:
       - "5432:5432"
     volumes:

--- a/env.tmpl
+++ b/env.tmpl
@@ -1,5 +1,5 @@
 # 1Password-injectable template for local development secrets.
 # Materialize the gitignored .env with:  task db:env
-POSTGRES_USER=op://Dev/clairbuoyant/DB_USERNAME
-POSTGRES_PASSWORD=op://Dev/clairbuoyant/DB_PASSWORD
-POSTGRES_DB=op://Dev/clairbuoyant/DB_NAME
+DB_USERNAME=op://Dev/clairbuoyant - local/DB_USERNAME
+DB_PASSWORD=op://Dev/clairbuoyant - local/DB_PASSWORD
+DB_NAME=op://Dev/clairbuoyant - local/DB_NAME

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package store_test
 
 import (
@@ -14,14 +16,15 @@ import (
 	"github.com/clairBuoyant/swellhub/pkg/noaa"
 )
 
-// testStore connects to TEST_DATABASE_URL, applies migrations, and returns a
-// Store. Tests are skipped when the env var is unset so unit runs don't need a
-// database.
+// testStore connects to TEST_DB_URL, applies migrations, and returns a Store. These
+// tests are gated by the `integration` build tag, so a plain `go test ./...`
+// never runs them — only `task db:test` / CI (with -tags=integration) do, which
+// point TEST_DB_URL at a throwaway database. Skipped if it is unset.
 func testStore(t *testing.T) (*store.PgStore, *pgxpool.Pool) {
 	t.Helper()
-	dsn := os.Getenv("TEST_DATABASE_URL")
+	dsn := os.Getenv("TEST_DB_URL")
 	if dsn == "" {
-		t.Skip("TEST_DATABASE_URL not set; skipping store integration tests")
+		t.Skip("TEST_DB_URL not set; skipping store integration tests")
 	}
 	if err := db.Migrate(dsn); err != nil {
 		t.Fatalf("migrate: %v", err)


### PR DESCRIPTION
## What

Hardens `go-ci.yml` and the database-backed integration-test path:

1. **No committed CI credentials** — the disposable CI Postgres service receives `DB_USERNAME`, `DB_PASSWORD`, and `DB_NAME` from the `test` environment's Actions secrets or matching Dependabot secrets.
2. **Integration tests require an explicit build tag** — `internal/store` tests carry `//go:build integration`, so a plain `go test ./...` never compiles or runs them.
3. **Tests use a dedicated database URL** — CI and `task db:test` set `TEST_DB_URL`, keeping integration tests isolated from the application's ambient `DB_URL`.
4. **Local configuration is infrastructure-neutral** — local inputs consistently use `DB_USERNAME`, `DB_PASSWORD`, and `DB_NAME`; Compose maps them to the names required by the Postgres image.

## Verification

- `git diff --check`
- `go test ./... -count=1`
- `go test -tags=integration ./... -count=1`
- `task db:up` followed by `task db:test`
- `task db:test` dry-run with both `DB_URL` and `TEST_DB_URL` set confirms the test-specific URL wins
- Ordinary PR `go-ci` starts Postgres and runs `internal/store` successfully

## Secrets

`DB_USERNAME`, `DB_PASSWORD`, and `DB_NAME` exist in both the `test` Actions environment and repository Dependabot secrets. No Go Dependabot PR is currently open, so the bot-authored path will be observed on the next scheduled update without blocking this merge.

Closes #226
Closes #229
Refs #206
