### PR TITLE
chore(github): bump all actions to latest version

### DIFF
--- a/.github/workflows/commit-linter.yml
+++ b/.github/workflows/commit-linter.yml
@@ -28,7 +28,7 @@ jobs:
             github.com:443
 
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -36,8 +36,8 @@ jobs:
       TEST_DATABASE_URL: postgres://swellhub:swellhub@127.0.0.1:5432/swellhub?sslmode=disable
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -28,12 +28,12 @@ jobs:
             github.com:443
 
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Run markdownlint
-        uses: nosborn/github-action-markdown-cli@508d6cefd8f0cc99eab5d2d4685b1d5f470042c1  # v3.5.0
+        uses: nosborn/github-action-markdown-cli@508d6cefd8f0cc99eab5d2d4685b1d5f470042c1 # v3.5.0
         with:
           files: .
           ignore_path: .markdownlintignore

--- a/.github/workflows/proto-linter.yml
+++ b/.github/workflows/proto-linter.yml
@@ -15,26 +15,13 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint
         run: buf lint
-      # TODO(#215): drop this baseline guard once main has a buf.yaml. Breaking-
-      # change detection needs a baseline on main, so we skip it until main has a
-      # buf.yaml (i.e. on the PR that first introduces protobuf); afterwards it
-      # runs on every change and the guard can be removed.
-      - name: Check baseline exists on main
-        id: baseline
-        run: |
-          if git cat-file -e origin/main:buf.yaml 2>/dev/null; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
       - name: Breaking change check
-        if: steps.baseline.outputs.exists == 'true'
-        run: buf breaking --against '.git#branch=main'
+        run: buf breaking --against '.git#ref=refs/remotes/origin/main'

--- a/.github/workflows/security-semgrep.yml
+++ b/.github/workflows/security-semgrep.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: 0 3 * * *
 
-permissions:  # added using https://github.com/step-security/secure-workflows
+permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run Semgrep
         run: semgrep ci

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -20,17 +20,17 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: block
           allowed-endpoints: >
             github.com:443
             api.github.com:443
 
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Run yamllint
-        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  # v3.1.1
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1


### PR DESCRIPTION
## Summary

- Bump all GitHub Actions across the repo's workflows to their latest releases, keeping every action pinned to a commit SHA.
- Close #215 by removing the temporary baseline guard in that workflow; it only existed to skip breaking-change detection until `main` carried a `buf.yaml`, which has been true since #214. The check now runs unconditionally.