### PR TITLE
chore(ci): note upcoming GITHUB_TOKEN format rollout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ Agent instructions for `clairBuoyant/swellhub`. Add project-specific guidance ab
 the section below; the `## Agent skills` block is managed by the
 `setup-matt-pocock-skills` skill and points at the per-topic docs under `docs/agents/`.
 
+## CI conventions
+
+- **GitHub token format:** the Actions `GITHUB_TOKEN` is rolling out as a longer (~520-char), `ghs_`-prefixed JWT ([2026-05-15 changelog](https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/)). We pass it opaquely, so there's nothing to change today — but never assume a token's length or shape in new CI tooling, regexes, or token-storing DB columns (allow ≥520 chars and the dotted `ghs_…` form). No deprecation date announced yet.
+
 ## Agent skills
 
 ### Issue tracker


### PR DESCRIPTION
Adds a CI-conventions note to `AGENTS.md` flagging the upcoming Actions `GITHUB_TOKEN` format change — a longer (~520-char), `ghs_`-prefixed JWT (per the [2026-05-15 GitHub changelog](https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/)).

We consume the token opaquely (implicitly via `actions/checkout`, and as an input to maintained first-party actions in `labeler`/`pr-linter`/`proto-linter`), so **no workflow change is required today** — verified repo-wide that nothing parses, validates, length-checks, or stores a GitHub token, and no DB column holds one. This note just records the constraint so future CI tooling, regexes, or token-storing columns don't bake in length/format assumptions.

No deprecation date has been announced (the changelog defers it).