### PR TITLE
fix(noaa): bound ndbc fetches with http timeout and context

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/clairBuoyant/swellhub/internal/db"
 	"github.com/clairBuoyant/swellhub/internal/ingest"
@@ -26,7 +27,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
+	// In-process backstop under the workflow's timeout-minutes cap; per-request
+	// bounds live in pkg/noaa's http.Client.
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	defer cancel()
 	pool, err := db.NewPool(ctx, dsn)
 	if err != nil {
 		logger.Error("connect postgres", "error", err)

--- a/cmd/noaa/main.go
+++ b/cmd/noaa/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -28,7 +29,7 @@ func main() {
 			printUsageAndExit()
 		}
 
-		mos, err := noaa.Realtime(*stationID, noaa.TXT)
+		mos, err := noaa.Realtime(context.Background(), *stationID, noaa.TXT)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error running Realtime: %v\n", err)
 			os.Exit(1)
@@ -40,7 +41,7 @@ func main() {
 	case "active":
 		activeCmd.Parse(os.Args[2:])
 
-		stations, err := noaa.ActiveStations()
+		stations, err := noaa.ActiveStations(context.Background())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error running ActiveStations: %v\n", err)
 			os.Exit(1)

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -41,7 +41,7 @@ func Buoy(app application) http.HandlerFunc {
 		}
 
 		// TODO(@kylejb): add validation for stationID too
-		data, err := noaa.Realtime(r.PathValue("stationID"), dataset)
+		data, err := noaa.Realtime(r.Context(), r.PathValue("stationID"), dataset)
 		if err != nil {
 			// TODO(@kylejb): dynamically provide http status code
 			app.ServerError(w, r, errors.NewAppError(http.StatusNotAcceptable, "failed to encode response", err), http.StatusNotAcceptable)
@@ -55,7 +55,7 @@ func Buoy(app application) http.HandlerFunc {
 
 func Buoys(app application) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		data, err := noaa.ActiveStations()
+		data, err := noaa.ActiveStations(r.Context())
 		if err != nil {
 			app.ServerError(w, r, errors.NewAppError(http.StatusBadRequest, "failed to retrieve active stations from NDBC", err), http.StatusBadRequest)
 			return

--- a/internal/http/spot.go
+++ b/internal/http/spot.go
@@ -15,7 +15,7 @@ import (
 
 // realtimeFunc fetches realtime observations for a station. Injected so tests
 // can stub NDBC.
-type realtimeFunc func(stationID string, dataset noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error)
+type realtimeFunc func(ctx context.Context, stationID string, dataset noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error)
 
 // spotService implements the Connect SpotService (spotv1connect.SpotServiceHandler):
 // it serves configured spots, each joined with the latest conditions from its
@@ -46,7 +46,7 @@ func (s *spotService) ListSpots(
 // GetSpot returns a spot joined with the latest conditions from its primary
 // reachable buoy. Unknown id yields CodeNotFound.
 func (s *spotService) GetSpot(
-	_ context.Context,
+	ctx context.Context,
 	req *connect.Request[spotv1.GetSpotRequest],
 ) (*connect.Response[spotv1.GetSpotResponse], error) {
 	sp, ok := spot.ByID(req.Msg.GetId())
@@ -57,16 +57,16 @@ func (s *spotService) GetSpot(
 	return connect.NewResponse(&spotv1.GetSpotResponse{
 		SpotConditions: &spotv1.SpotConditions{
 			Spot:       toProtoSpot(sp),
-			Conditions: s.latestConditions(sp),
+			Conditions: s.latestConditions(ctx, sp),
 		},
 	}), nil
 }
 
 // latestConditions returns the most recent observation from the first mapped
 // buoy that responds with data, or nil if none do.
-func (s *spotService) latestConditions(sp spot.Spot) *spotv1.Conditions {
+func (s *spotService) latestConditions(ctx context.Context, sp spot.Spot) *spotv1.Conditions {
 	for _, buoyID := range sp.BuoyIDs {
-		obs, err := s.realtime(buoyID, noaa.TXT)
+		obs, err := s.realtime(ctx, buoyID, noaa.TXT)
 		if err != nil {
 			s.logger.Warn("buoy fetch failed", "spot", sp.ID, "buoy", buoyID, "error", err)
 			continue

--- a/internal/http/spot_test.go
+++ b/internal/http/spot_test.go
@@ -22,7 +22,7 @@ func testService(fn realtimeFunc) *spotService {
 }
 
 func TestListSpots(t *testing.T) {
-	svc := testService(func(string, noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+	svc := testService(func(context.Context, string, noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
 		return nil, nil
 	})
 
@@ -46,7 +46,7 @@ func TestListSpots(t *testing.T) {
 }
 
 func TestGetSpotNotFound(t *testing.T) {
-	svc := testService(func(string, noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+	svc := testService(func(context.Context, string, noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
 		return nil, nil
 	})
 
@@ -75,7 +75,7 @@ func TestGetSpotConditions(t *testing.T) {
 	}{
 		{
 			name: "primary buoy returns data",
-			fn: func(id string, _ noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+			fn: func(_ context.Context, id string, _ noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
 				if id == "44065" {
 					return []noaa.MeteorologicalObservation{obs}, nil
 				}
@@ -85,7 +85,7 @@ func TestGetSpotConditions(t *testing.T) {
 		},
 		{
 			name: "falls back to next buoy when primary errors",
-			fn: func(id string, _ noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+			fn: func(_ context.Context, id string, _ noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
 				switch id {
 				case "44065":
 					return nil, errors.New("ndbc unavailable")
@@ -98,7 +98,7 @@ func TestGetSpotConditions(t *testing.T) {
 		},
 		{
 			name: "no usable data from any buoy",
-			fn: func(string, noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+			fn: func(context.Context, string, noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
 				return nil, nil
 			},
 			wantNil: true,

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -18,7 +18,7 @@ type Upserter interface {
 }
 
 // RealtimeFunc fetches realtime observations for a station (noaa.Realtime).
-type RealtimeFunc func(stationID string, dataset noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error)
+type RealtimeFunc func(ctx context.Context, stationID string, dataset noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error)
 
 // Run fetches realtime observations for each station and upserts every returned
 // row (idempotent on station+datetime). It is best-effort: an error for one
@@ -29,7 +29,7 @@ func Run(ctx context.Context, store Upserter, fetch RealtimeFunc, stationIDs []s
 	var inserted int
 	var failures []error
 	for _, id := range stationIDs {
-		obs, err := fetch(id, noaa.TXT)
+		obs, err := fetch(ctx, id, noaa.TXT)
 		if err != nil {
 			logger.Warn("buoy fetch failed", "buoy", id, "error", err)
 			failures = append(failures, fmt.Errorf("fetch buoy %s: %w", id, err))

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -31,7 +31,7 @@ func TestRun(t *testing.T) {
 		{Datetime: time.Now()},
 		{Datetime: time.Now().Add(-time.Hour)},
 	}
-	fetch := func(id string, _ noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+	fetch := func(_ context.Context, id string, _ noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
 		switch id {
 		case "GOOD":
 			return two, nil
@@ -57,7 +57,7 @@ func TestRun(t *testing.T) {
 
 func TestRunContinuesPastUpsertError(t *testing.T) {
 	obs := []noaa.MeteorologicalObservation{{Datetime: time.Now()}}
-	fetch := func(string, noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+	fetch := func(context.Context, string, noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
 		return obs, nil
 	}
 	st := &fakeStore{failOn: "BAD"}
@@ -73,7 +73,7 @@ func TestRunContinuesPastUpsertError(t *testing.T) {
 
 func TestRunReportsFetchErrorAfterContinuing(t *testing.T) {
 	fetchErr := errors.New("ndbc down")
-	fetch := func(id string, _ noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
+	fetch := func(_ context.Context, id string, _ noaa.RealtimeDataset) ([]noaa.MeteorologicalObservation, error) {
 		if id == "BAD" {
 			return nil, fetchErr
 		}

--- a/pkg/noaa/noaa.go
+++ b/pkg/noaa/noaa.go
@@ -1,6 +1,7 @@
 package noaa
 
 import (
+	"context"
 	"encoding/csv"
 	"io"
 	"log/slog"
@@ -10,6 +11,11 @@ import (
 	"strings"
 	"time"
 )
+
+// httpClient bounds every NDBC/NOAA request. Realtime files are small, so a
+// healthy fetch completes in seconds; the Timeout keeps a stalled upstream
+// from hanging a run when the caller's context has no deadline.
+var httpClient = &http.Client{Timeout: 60 * time.Second}
 
 func extractHeaders(r *csv.Reader) ([]string, []string, error) {
 	var headers []string
@@ -33,8 +39,12 @@ func extractHeaders(r *csv.Reader) ([]string, []string, error) {
 	return headers, units, nil
 }
 
-func request(url string) ([]byte, int, error) {
-	response, err := http.Get(url)
+func request(ctx context.Context, url string) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	response, err := httpClient.Do(req)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -177,8 +187,8 @@ func parseRecordToStruct(record []string, mo *MeteorologicalObservation) error {
 	return nil
 }
 
-func realtimeMeteorological(url string) ([]MeteorologicalObservation, error) {
-	body, statusCode, err := request(url)
+func realtimeMeteorological(ctx context.Context, url string) ([]MeteorologicalObservation, error) {
+	body, statusCode, err := request(ctx, url)
 	if err != nil {
 		return nil, NewRequestError(statusCode, err.Error(), err)
 	}

--- a/pkg/noaa/noaa_test.go
+++ b/pkg/noaa/noaa_test.go
@@ -1,6 +1,31 @@
 package noaa
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRequestFailsFastWhenServerHangs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // never respond; unblocks when the client gives up
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, _, err := request(ctx, srv.URL)
+	if err == nil {
+		t.Fatal("request against hanging server = nil error, want context deadline error")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("request took %v to fail, want prompt cancellation", elapsed)
+	}
+}
 
 func TestParseValuePreservesMissingAndZero(t *testing.T) {
 	missing, err := parseValue("MM")

--- a/pkg/noaa/realtime.go
+++ b/pkg/noaa/realtime.go
@@ -1,6 +1,7 @@
 package noaa
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -128,13 +129,13 @@ func (o MeteorologicalObservation) MarshalJSON() ([]byte, error) {
 // 	)
 // }
 
-func Realtime(stationId string, dataset RealtimeDataset) ([]MeteorologicalObservation, error) {
+func Realtime(ctx context.Context, stationId string, dataset RealtimeDataset) ([]MeteorologicalObservation, error) {
 	if valid := dataset.IsValid(); !valid {
 		return nil, fmt.Errorf("unknown dataset '%s'", dataset)
 	}
 	url := fmt.Sprintf("%s/%s.%s", RealtimeURL, stationId, dataset)
 
-	data, err := realtimeMeteorological(url)
+	data, err := realtimeMeteorological(ctx, url)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/noaa/stations.go
+++ b/pkg/noaa/stations.go
@@ -1,6 +1,7 @@
 package noaa
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 )
@@ -29,10 +30,10 @@ type Station struct {
 // TAO stations are excluded. Each station has an indicator showing
 // whether the elevation, meteorological data, single point or profile
 // currents data, water quality data, or DART data are available.
-func ActiveStations() (*Stations, error) {
+func ActiveStations(ctx context.Context) (*Stations, error) {
 	url := fmt.Sprintf("%s.%s", ActiveStationsURL, "xml")
 
-	response, code, err := request(url)
+	response, code, err := request(ctx, url)
 	if err != nil {
 		return nil, NewRequestError(code, "NDBC request error", err)
 	}


### PR DESCRIPTION
Fixes #242

## Problem

Scheduled ingest runs died as `cancelled` from 06-22 through 06-27: `pkg/noaa`'s `request()` used bare `http.Get` (default client, no timeout) and no `context` threaded through the fetch path, so a stalled NDBC response hung until the workflow's `timeout-minutes` killed the job. The `027f2bf` mitigation (daily cadence, 30-min cap) restored the data clock, but a slow NDBC day still burned the full 30 minutes instead of failing fast.

## Fix

- `pkg/noaa`: package-level `http.Client{Timeout: 60s}`; `request()` now takes a `ctx` via `http.NewRequestWithContext`. `Realtime` and `ActiveStations` gain a `ctx` first parameter.
- `internal/ingest`: `RealtimeFunc` takes `ctx`; `Run` passes its context to each fetch. Existing behavior (log + continue per station) is unchanged — a slow station is now a logged skip instead of a dead run.
- `cmd/ingest`: 25-minute run-level `context.WithTimeout` as an in-process backstop under the workflow's 30-minute cap (the 06-28 run legitimately took ~12.5 min, so the budget stays well above that).
- `internal/http`: `Buoy`/`Buoys` handlers and `spotService` pass the request context, so client disconnects cancel upstream NDBC calls.
- `cmd/noaa`: passes `context.Background()` (bounded by the client timeout).

No workflow changes — daily cadence and the preprod approval gate stay as-is.

## Testing

- New regression test `TestRequestFailsFastWhenServerHangs`: hanging `httptest` server + 100ms ctx deadline must return an error promptly.
- `go build ./... && go vet ./... && go test ./...` clean.
- Local end-to-end against docker Postgres: `task db:up && task db:migrate && task db:ingest` → `ingest complete, stations=3, observations_inserted=2045`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)