### PR TITLE
fix(web): re-enable app render test with mocked auth and connect transport

### DIFF
--- a/web/src/app.test.tsx
+++ b/web/src/app.test.tsx
@@ -1,13 +1,27 @@
 import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import App from './app';
 
-// TODO(@kylejb): stale since the AppProvider/router restructure — App renders a
-// Spinner until the auth query settles, which never happens in jsdom without a
-// mocked Connect transport. Re-enable once a transport mock exists.
-test.skip("renders 'clairBuoyant' in header", () => {
+// AuthLoader blocks rendering until the authenticated-user query settles. That
+// query goes through the axios api-client, so resolve it with no signed-in
+// user; AuthLoader then renders its children (the router).
+vi.mock('@lib/api-client', () => ({
+  api: {
+    get: vi.fn().mockResolvedValue(null),
+    post: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Keep Connect RPCs off the network in jsdom: serve them from an in-memory
+// router transport instead (no services registered — calls reject cleanly).
+vi.mock('@lib/connect', async () => {
+  const { createRouterTransport } = await import('@connectrpc/connect');
+  return { transport: createRouterTransport(() => {}) };
+});
+
+test("renders 'clairBuoyant' in header", async () => {
   render(<App />);
-  const linkElement = screen.getByText(/clairBuoyant/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = await screen.findByText(/clairBuoyant/i);
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
Closes #247. Stacked on #245 — based on `fix/216-web-eslint-deps` so the diff stays clean; retarget/rebase onto `main` after #245 merges.

## What

Re-enables the skipped `app.test.tsx` render test.

- Mocks the axios `api-client` so the `/auth/me` user query resolves with no signed-in user — `AuthLoader` settles and renders its children instead of spinning forever in jsdom.
- Swaps `@lib/connect`'s transport for an in-memory `createRouterTransport(() => {})` so any Connect RPC stays off the network (rejects cleanly as unimplemented).
- Uses `await screen.findByText(...)` since the landing route is lazy-loaded.

Note: the TODO suggested the Connect transport was the blocker, but the blocking query is actually the **axios** `/auth/me` call (`getUser` in `src/lib/auth.tsx`); the transport mock is for hermeticity.

## Verification

- `npx vitest run` — 1 passed (previously 1 skipped)
- `npm run lint` — 0 errors, 7 pre-existing warnings (unchanged)
- `npm run build` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)