### PR TITLE
fix(web): make tsc noemit clean and enforce typecheck in web ci

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Typecheck
+        run: npx tsc --noEmit
       - name: Build
         run: npm run build
       - name: Test

--- a/web/src/components/ui/form/form.tsx
+++ b/web/src/components/ui/form/form.tsx
@@ -155,21 +155,27 @@ const FormMessage = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagrap
 );
 FormMessage.displayName = 'FormMessage';
 
-type FormProps<TFormValues extends FieldValues, Schema> = {
-  onSubmit: SubmitHandler<TFormValues>;
+type FormProps<Schema extends ZodType<FieldValues, FieldValues>> = {
+  onSubmit: SubmitHandler<z.output<Schema>>;
   schema: Schema;
   className?: string;
-  children: (methods: UseFormReturn<TFormValues>) => ReactNode;
-  options?: UseFormProps<TFormValues>;
+  children: (methods: UseFormReturn<z.input<Schema>, unknown, z.output<Schema>>) => ReactNode;
+  options?: UseFormProps<z.input<Schema>, unknown, z.output<Schema>>;
   id?: string;
 };
 
-function Form<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Schema extends ZodType<any, any, any>,
-  TFormValues extends FieldValues = z.infer<Schema>,
->({ onSubmit, children, className, options, id, schema }: FormProps<TFormValues, Schema>) {
-  const form = useForm({ ...options, resolver: zodResolver(schema) });
+function Form<Schema extends ZodType<FieldValues, FieldValues>>({
+  onSubmit,
+  children,
+  className,
+  options,
+  id,
+  schema,
+}: FormProps<Schema>) {
+  const form = useForm<z.input<Schema>, unknown, z.output<Schema>>({
+    ...options,
+    resolver: zodResolver(schema),
+  });
   return (
     <FormProvider {...form}>
       <form className={cn('space-y-6', className)} onSubmit={form.handleSubmit(onSubmit)} id={id}>

--- a/web/src/lib/react-query-auth.tsx
+++ b/web/src/lib/react-query-auth.tsx
@@ -29,7 +29,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import { type ReactNode, useCallback } from 'react';
+import { type JSX, type ReactNode, useCallback } from 'react';
 
 export interface ReactQueryAuthConfig<User, LoginCredentials, RegisterCredentials> {
   userFn: QueryFunction<User, QueryKey>;


### PR DESCRIPTION
Closes #248. Stacked on #245 — based on `fix/216-web-eslint-deps` (where `web-ci.yml` and the lockfile repair live); retarget/rebase onto `main` after #245 merges.

## What

Fixes the two latent type errors that made `npx tsc --noEmit` fail in `web/` (nothing ran tsc before), then enforces it in CI.

- **`form.tsx`** — with zod 4 + @hookform/resolvers 5, `zodResolver` returns `Resolver<input<Schema>, any, output<Schema>>`, which no longer unifies with a single `TFormValues`. `Form` is now generic over the schema alone and derives the `useForm` generics as `useForm<z.input<Schema>, unknown, z.output<Schema>>`; `onSubmit` receives `z.output<Schema>` (the parsed/transformed values — matters for `registerInputSchema`, whose `.default()`s make input ≠ output). Call sites (`login-form.tsx`, `register-form.tsx`) rely on inference and compile unchanged.
- **`react-query-auth.tsx`** — React 19 removed the global `JSX` namespace; import `type JSX` from `react`.
- **`web-ci.yml`** — add a `Typecheck` step (`npx tsc --noEmit`) between Lint and Build.

## Verification

- `npx tsc --noEmit` — clean (was 4 errors across 2 files)
- `npx vitest run`, `npm run lint`, `npm run build` — all pass, warning count unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)