### PR TITLE
fix(web): enable core react-hooks rules and align tsconfig lib with target

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -52,6 +52,8 @@ export default defineConfig(
       'react/button-has-type': 'error',
       'react/prop-types': ['off'],
       'react/react-in-jsx-scope': ['off'],
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
   },

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "types": ["node", "vite/client"],
     "module": "ESNext",
     "outDir": "dist",


### PR DESCRIPTION
Closes #260

Two small gaps left after the #216 web-deps work, split out per review.

## Changes

- **`eslint.config.js`** — the `react-hooks` plugin was registered but no rules were enabled, so `rules-of-hooks`/`exhaustive-deps` never ran. Enable the two core rules (`rules-of-hooks: error`, `exhaustive-deps: warn`). Deliberately scoped to the classic two — not v7's full 17-rule `recommended` (React Compiler-era rules), which is a larger, later step.
- **`tsconfig.json`** — `lib` was `ES2020` while `target` is `ESNext`, so the type-checker rejected ES2021+ built-ins the build already ships. Bump `lib` to `ESNext` (types-only; adds no polyfills).

## Verification

`web/` with the FA token sourced:
- `npm run lint` — 0 errors; the 7 pre-existing `react-refresh/only-export-components` warnings are unchanged (separate sweep). **No new** `rules-of-hooks` errors or `exhaustive-deps` warnings — existing hooks code already complies. Confirmed the rules are live via `eslint --print-config` (`rules-of-hooks: [2]`, `exhaustive-deps: [1]`).
- `npx tsc --noEmit` — clean.
- `npm run build` and `npm test -- --run` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)